### PR TITLE
ci: update test rpc url with spec key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,9 @@ jobs:
         continue-on-error: true
       - name: Retry if fail forge test
         if: steps.forge_test.outcome == 'failure'
-        uses: nick-invision/retry@v3
+        uses: nick-fields/retry@v3
         with:
-          timeout_minutes: 3   # Total time before giving up
+          timeout_minutes: 10   # Total time before giving up
           max_attempts: 3      # Total number of attempts
           command: forge test --fork-url https://arbitrum.llamarpc.com/sk_llama_3f92d666a172604faf69e469a67ec6ea
-          delay_seconds: 60    # Delay between retries
+          retry_wait_seconds: 60    # Delay between retries


### PR DESCRIPTION
## Change Information

更新 ci: test 中的 rpc url，使用了个人申请的免费版本 rpc url (60 req(s)/min)

这个测试 rpc url 应当会比不带 key 的测试 url 拥有更高的成功机率(取决于调用频率)。
同时添加了一些用于 retry 的脚本，以适应限频的测试网 rpc 。




