### PR TITLE
chore: bump solint version & ignore `gas-custom-error`

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -12,7 +12,6 @@
     ],
     "contract-name-camelcase": "off",
     "const-name-snakecase": "off",
-    "custom-errors": "off",
     "func-name-mixedcase": "off",
     "func-visibility": [
       "error",
@@ -28,6 +27,7 @@
     "no-empty-blocks": "off",
     "not-rely-on-time": "off",
     "one-contract-per-file": "off",
-    "var-name-mixedcase": "off"
+    "var-name-mixedcase": "off",
+    "gas-custom-errors": "off"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ds-test": "github:dapphub/ds-test#master",
     "forge-std": "github:foundry-rs/forge-std#v1.8.1",
     "prettier": "^3.2.5",
-    "solhint": "^4.5.4"
+    "solhint": "^5.0.1"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.9.6",

--- a/test/unit/MestERC1155.t.sol
+++ b/test/unit/MestERC1155.t.sol
@@ -2,7 +2,7 @@
 
 pragma solidity 0.8.25;
 
-import {BaseTest} from "../BaseTest.t.sol";
+import { BaseTest } from "../BaseTest.t.sol";
 
 contract MestERC1155Tests is BaseTest {
     address private mockFactory = address(1);

--- a/test/unit/MestSharesFactory.t.sol
+++ b/test/unit/MestSharesFactory.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.25;
 
 import { console } from "forge-std/console.sol";
-import {BaseTest} from "../BaseTest.t.sol";
+import { BaseTest } from "../BaseTest.t.sol";
 import { IYieldAggregator } from "contracts/interface/IYieldAggregator.sol";
 import { IMestShare } from "contracts/interface/IMestShare.sol";
 

--- a/test/unit/YieldAggregator.t.sol
+++ b/test/unit/YieldAggregator.t.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.25;
 
 import { MestSharesFactoryV1 } from "contracts/core/MestSharesFactoryV1.sol";
-import {BaseTest} from "../BaseTest.t.sol";
+import { BaseTest } from "../BaseTest.t.sol";
 import { console } from "forge-std/console.sol";
 
 contract YieldAggregatorTests is BaseTest {

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,10 +646,10 @@ solady@^0.0.198:
   resolved "https://registry.yarnpkg.com/solady/-/solady-0.0.198.tgz#fabcf4a6d679ba11137a0e16d8d26f5aa7b0f2b0"
   integrity sha512-zK3B9vJM8NBL3kicwnVzNxkRI0bCIEipxhQHf67vnU54oZxlZxOUrFSbtYYz11WwZsjm5MfGc7jMZ+AGqlHjEQ==
 
-solhint@^4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-4.5.4.tgz#171cf33f46c36b8499efe60c0e425f6883a54e50"
-  integrity sha512-Cu1XiJXub2q1eCr9kkJ9VPv1sGcmj3V7Zb76B0CoezDOB9bu3DxKIFFH7ggCl9fWpEPD6xBmRLfZrYijkVmujQ==
+solhint@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-5.0.1.tgz#f0f783bd9d945e5a27b102295a3f28edba241d6c"
+  integrity sha512-QeQLS9HGCnIiibt+xiOa/+MuP7BWz9N7C5+Mj9pLHshdkNhuo3AzCpWmjfWVZBUuwIUO3YyCRVIcYLR3YOKGfg==
   dependencies:
     "@solidity-parser/parser" "^0.18.0"
     ajv "^6.12.6"


### PR DESCRIPTION
## Change Information

- 更新 solhint 版本
- 更新 solhint 规则，现在不会在 ci lint 任务中抛出不期望的 warnings